### PR TITLE
Restructure index page list and create vision page

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -27,6 +27,7 @@ highlight_theme = "cheerfully-light"
 navigation = [
   { name = "Home", target = "/" },
   { name = "About us", target = "/about/" },
+  { name = "Vision", target = "/vision/" },
   { name = "Courses", target = "/courses/" },
   { name = "Blog", target = "/blog/" },
   { name = "Contact", target = "/contact/" },

--- a/content/_index.md
+++ b/content/_index.md
@@ -13,13 +13,9 @@
 
 {{ div(attributes='class="uk-width-1-2@m"') }}
 
-We are starting a RSE group at UiT, following the footsteps of [UK-based
-groups](https://society-rse.org/) and the [RSE group at Aalto
-University](https://scicomp.aalto.fi/).
-
-Our vision is to put UiT on the map as a place where research groups have
-access to best in class RSE services. Over time we wish to attract excellent
-staff, research groups, funding, collaborations, and attention.
+We want to help all researchers and students at UiT to develop and improve
+their research software. This can span from simple R or Python scripts to
+complex GPU enabled software packages.
 
 {{ enddiv() }}
 
@@ -28,35 +24,43 @@ staff, research groups, funding, collaborations, and attention.
 
 ## Office hours
 
-Want help with anything code related?  Visit us during our
-office hours **every Wednesday 14:00 - 15:00** in
-[room A209 in Modulbygget](https://use.mazemap.com/#v=1&zlevel=2&center=18.972617,69.683509&zoom=16.3&campusid=5&sharepoitype=poi&sharepoi=174370).
+Want help with anything code related?  Visit us during our office hours.
+
+**Every Wednesday 14:00 - 15:00** in [room A209 in
+Modulbygget](https://use.mazemap.com/#v=1&zlevel=2&center=18.972617,69.683509&zoom=16.3&campusid=5&sharepoitype=poi&sharepoi=174370).
 
 
 ## What we offer
 
 {{ div(attributes='class="uk-column-1-2@l"') }}
 
-- [Short presentation slide deck](https://cicero.xyz/v3/remark/0.14.0/github.com/uit-no/rse-presentations/main/2022-rse-intro.md/) for research groups
-- **Code review**: we look together at your code/script and give constructive feedback and advice
-- Consulting and help with programming and research software engineering
-- Making code more reproducible and reusable
-- Help with software licenses and open sourcing
-- Help with Git, GitHub, and GitLab
-- Help with moving your work/project/code/data to Git
-- Help with organization of reusable and reproducible Jupyter notebooks and
-  Binder
-- Advice and help how to best document code
-- Advice about whether to use YAML or CSV or JSON or TOML or something else
-- Packaging and sharing software
-- Containerization (Singularity, Docker)
-- Help with pip, PyPI, and Conda
-- Help publishing your code
-- Improving scaling, CPU, and memory footprint of research codes
-- Help with modularizing your code
-- Consulting and help with web development (static websites, JavaScript, HTML, CSS frameworks)
-- **If you have questions about code you wrote or want to write, please [contact us](/contact) or come
-  and talk to us**
+- **Help with improving your scripts/code**
+  - Code review: we look together at your code/script and give constructive feedback and advice
+  - Making code more reproducible and reusable
+  - Advice and help how to best document code
+  - Advice about whether to use YAML or CSV or JSON or TOML or something else
+  - Consulting and help with web development (static websites, JavaScript, HTML, CSS frameworks)
+- **Help with organising your code**
+  - Help with modularizing your code
+  - Help with moving your work/project/code/data to Git
+  - Help with Git, GitHub, and GitLab
+  - Help with organization of reusable and reproducible Jupyter notebooks and
+    Binder
+- **Help with sharing your code**
+  - Help publishing your code
+  - Help with software licenses and open sourcing
+  - Packaging and sharing software
+  - Containerization (Singularity, Docker)
+  - Help with pip, PyPI, and Conda
+- **Help with running your code faster**
+  - Improving scaling, CPU, and memory footprint of research codes
+  - Porting to GPU
+  - Moving from local computer to cloud or high-performance computing (using e.g. [NRIS resources](https://documentation.sigma2.no/index.html))
+
+**If you have questions about code you wrote or want to write, please [contact
+us](/contact) or come and talk to us**
+
+[Short presentation slide deck](https://cicero.xyz/v3/remark/0.14.0/github.com/uit-no/rse-presentations/main/2022-rse-intro.md/) for research groups
 
 {{ enddiv() }}
 

--- a/content/vision.md
+++ b/content/vision.md
@@ -1,0 +1,14 @@
++++
++++
+
+# Vision
+
+Our vision is to put UiT on the map as a place where research groups have
+access to best in class RSE services. So that researchers and students can get
+the help they need to be able to focus on excellent research.  Over time we
+wish to attract first class staff, research groups, funding, collaborations,
+and attention.
+
+We are starting a RSE group at UiT, following the footsteps of [UK-based
+groups](https://society-rse.org/) and the [RSE group at Aalto
+University](https://scicomp.aalto.fi/).


### PR DESCRIPTION
Definitely not perfect yet, but for me these categories make more sense than the unsorted list.
I also think the top text should contain the gist of what we want to do, so I put the old explanation into a new vision subpage. 

Please change what you see needs improvement.

Be aware that I didn't test it as I haven't installed zola yet.